### PR TITLE
Prevent multiple-definition errors when using multiple translation units

### DIFF
--- a/dataMCplotMaker/PlotMakingTools.h
+++ b/dataMCplotMaker/PlotMakingTools.h
@@ -21,7 +21,7 @@
 #include "TROOT.h"
 
 //Parse Parameters from options input string
-std::vector <std::string> GetParms(std::string blah){
+inline std::vector <std::string> GetParms(std::string blah){
   int a = -1;
   int length = blah.length();
   std::vector <std::string> options;
@@ -40,7 +40,7 @@ std::vector <std::string> GetParms(std::string blah){
 }
 
 //Turn parsed argument from string into const char*.  Remove leading and trailing whitespace
-std::string getString(std::string initial, std::string result){
+inline std::string getString(std::string initial, std::string result){
   int temp = initial.find(result); 
   std::string substring = initial.substr(temp+result.length());
   while (substring[0] == ' '){
@@ -56,7 +56,7 @@ std::string getString(std::string initial, std::string result){
 }
 
 //Needed for freaking vertical lines
-void DrawVerticalLine(Double_t x){
+inline void DrawVerticalLine(Double_t x){
   TLine l;
   l.SetLineStyle(2);
   l.SetLineWidth(2);

--- a/dataMCplotMaker/dataMCplotMaker.cc
+++ b/dataMCplotMaker/dataMCplotMaker.cc
@@ -4,6 +4,7 @@
 #include "TMath.h"
 
 bool do_background_syst = true;
+TStyle *tdrStyleAG = NULL;
 
 //Comparison to put smallest histogram on bottom of stack
 bool Integral(PlotInfo plot1, PlotInfo plot2){

--- a/dataMCplotMaker/dataMCplotMaker.h
+++ b/dataMCplotMaker/dataMCplotMaker.h
@@ -13,8 +13,6 @@ struct PlotInfo {
   std::string SignalTitle;
 };
 
-TStyle *tdrStyleAG = NULL;
-
 //Main function
 void dataMCplotMaker(TH1F* Data_in, std::vector <std::pair <TH1F*, TH1F*> > Backgrounds_pair_in, std::vector <std::string> Titles, std::string titleIn = "", std::string title2In = "", std::string options_string = "", std::vector <TH1F*> Signals_in = std::vector<TH1F*>(), std::vector <std::string> SignalTitles = std::vector<std::string>(), std::vector <Color_t> color_input = std::vector<Color_t>(), TH1F* overrideSyst=new TH1F());
 


### PR DESCRIPTION
Right now, three functions are explicitly defined in PlotMakingTools.h, and the object tdrStyleAG is explicitly defined in dataMCplotMaker.h. This has caused me some problems when I use the dataMCplotMaker in g++-compiled code.

If I have a few different scripts that #include dataMCplotMaker.h, and are compiled into one executable using g++, I get "multiple definition" errors for tdrStyleAG and the three functions in PlotMakingTools.h. (To better understand the problem, check out the second question [here](http://stackoverflow.com/questions/14909997/why-arent-my-include-guards-preventing-recursive-inclusion-and-multiple-symbol)).

The changes I'm proposing will fix the problems I'm having, and shouldn't affect users who compile these scripts in ROOT. But to be on the safe side, I'd appreciate it if someone else could test these changes with their ROOT-compiled code just to make sure I'm not breaking anything for them. Thanks!